### PR TITLE
pygtk requires python2

### DIFF
--- a/bl-exit
+++ b/bl-exit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python2
 
 import pygtk
 pygtk.require('2.0')

--- a/bl-exit
+++ b/bl-exit
@@ -6,7 +6,7 @@ import gtk
 import os
 import getpass
 
-class cb_exit:
+class bl_exit:
     def disable_buttons(self):
         self.cancel.set_sensitive(False)
         self.logout.set_sensitive(False)
@@ -118,5 +118,5 @@ def main():
     gtk.main()
 
 if __name__ == "__main__":
-    go = cb_exit()
+    go = bl_exit()
     main()


### PR DESCRIPTION
pygtk requires python2, but `#!/usr/bin/env python` points to python 3. This should be changed to explicitly point to python2.

I noticed this while trying to use this script on an Arch build, so maybe Debian handles this differently, but the proposed edit works just fine on Debian and allows this script to be used on other bases.

https://www.archlinux.org/news/python-is-now-python-3/
